### PR TITLE
Fix connecting to unix socket

### DIFF
--- a/src/NilPortugues/Sphinx/SphinxClient.php
+++ b/src/NilPortugues/Sphinx/SphinxClient.php
@@ -254,9 +254,11 @@ class SphinxClient
         assert(is_string($host));
         if ($host[0] == '/') {
             $this->_path = 'unix://' . $host;
+            return;
         }
         if (substr($host, 0, 7) == "unix://") {
             $this->_path = $host;
+            return;
         }
 
         $this->_host = $host;


### PR DESCRIPTION
Needed so connecting to unix socket can work. Otherwise _path is cleared later in method. If _path is cleared then _Connect will use default port instead of 0 and will fail. Original SphinxClient.php has those returns.